### PR TITLE
feat(add-models): add base models based on pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autoflake
 black
 isort
+pydantic
 setuptools

--- a/src/integra_mix/models.py
+++ b/src/integra_mix/models.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+
+from integra_mix.quantities import Quantity
+
+
+class Ingredient(Quantity):
+    source: str = Field(
+        default=None,
+        description="source of the ingredient, to evaluate the quality",
+    )
+
+
+class Integrator(BaseModel):
+    name: str = Field(default=[], description="name of the integrator")
+    nutritional_table: List[Ingredient] = Field(
+        default=[], description="list of ingredients of the integrator"
+    )
+    cost: float = Field(default=None, description="cost of the integrator")
+    vendor: str = Field(default=None, description="vendor associated to the cost")

--- a/src/integra_mix/quantities.py
+++ b/src/integra_mix/quantities.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+measurement_units = Literal["g", "mg"]
+measurement_units_to_standard = {"g": 10**-3, "mg": 10**-6}
+
+
+class Quantity(BaseModel):
+    name: str = Field(default=None, description="name of the quantity")
+    quantity: float = Field(default=None, description="numeric value of the quantity")
+    measurement_unit: measurement_units = Field(
+        default=None, description="measurement unit of the quantity"
+    )


### PR DESCRIPTION
 - add Quantity concept consisting of float and measurement unity to allow comparison of integrator using different measurement units
 - add Ingredient and Integrator as a list of Ingredient(s)
 - add pydantic to requirements.txt